### PR TITLE
Change the URL to fetch an empty main.tf file

### DIFF
--- a/bin/delete-namespace.rb
+++ b/bin/delete-namespace.rb
@@ -8,7 +8,7 @@ ENVIRONMENTS_GITHUB_REPO = 'cloud-platform-environments'
 # main.tf file for each one.
 EMPTY_MAIN_TF_URLS = {
   'cloud-platform-live-0.k8s.integration.dsd.io' => 'https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments-checker/master/resources/live0-main.tf',
-  'live-1.cloud-platform.service.justice.gov.uk' => 'https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/master/namespace-resources/resources-main-tf'
+  'live-1.cloud-platform.service.justice.gov.uk' => 'https://raw.githubusercontent.com/ministryofjustice/cloud-platform-environments/master/namespace-resources/resources/main.tf'
 }
 
 def main(namespace, destroy)

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/orphaned-namespace-checker
-VERSION := 2.14
+VERSION := 2.15
 
 build: .built-image
 


### PR DESCRIPTION
The namespace deleter uses a blank main.tf file from github.

depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/1651
which changes the location of the file we need.