### PR TITLE
Prevent error if tfstate object has no "modules"

### DIFF
--- a/lib/orphaned_namespace_checker/tf_state_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/tf_state_namespace_lister.rb
@@ -37,7 +37,9 @@ class TFStateNamespaceLister
 
     rtn = []
 
-    obj.fetch("modules").each do |tf_module|
+    modules = obj.fetch("modules", [])
+
+    modules.each do |tf_module|
       tf_module.fetch("resources").each do |resource|
         rtn << get_aws_type_and_id(resource)
       end

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 IMAGE := ministryofjustice/orphaned-namespace-checker
-VERSION := 2.14
+VERSION := 2.16
 
 build: .built-image
 


### PR DESCRIPTION
Not every statefile in the S3 bucket that stores
our terraform states represents a namespace.

For those which are not namespaces, there may not
be a "modules" key in the hash contained in the
statefile.

This change causes the environments checker to 
skip any statefile which doesn't have a "modules"
key.

It might be desirable to have a more definitive
test for "is this the statefile of a namespace?", 
but this seems sufficient, for now.