### PR TITLE
Update rack to 2.0.8 to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-oauth2 (1.9.3)
       activesupport
       attr_required

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 IMAGE := ministryofjustice/orphaned-namespace-checker
 
-VERSION := 2.16
+VERSION := 2.17
 
 build: .built-image
 


### PR DESCRIPTION
rack 2.0.7 has a low-priority vulnerability:
https://github.com/advisories/GHSA-hrqr-hxpp-chr3

This change updates rack to version 2.0.8, which
fixes the vulnerability.

A change to the concourse pipeline will also be
required, to use the later version of this docker
image.