### PR TITLE
Expect `kube-node-lease` namespace

### DIFF
--- a/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
@@ -6,6 +6,7 @@ class ClusterNamespaceLister
     default
     ingress-controllers
     kiam
+    kube-node-lease
     kube-public
     kube-system
     kuberos

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 IMAGE := ministryofjustice/orphaned-namespace-checker
 
-VERSION := 2.18
+VERSION := 2.19
 
 build: .built-image
 

--- a/spec/cluster_namespace_lister_spec.rb
+++ b/spec/cluster_namespace_lister_spec.rb
@@ -2,12 +2,14 @@ RSpec.describe ClusterNamespaceLister do
   let(:name_a) { double(name: "aaa") }
   let(:name_b) { double(name: "bbb") }
   let(:name_ks) { double(name: "kube-system") }
+  let(:name_knl) { double(name: "kube-node-lease") }
 
   let(:ns_a) { double(metadata: name_a) }
   let(:ns_b) { double(metadata: name_b) }
   let(:ns_ks) { double(metadata: name_ks) }
+  let(:ns_knl) { double(metadata: name_knl) }
 
-  let(:namespaces) { [ns_a, ns_b, ns_ks] }
+  let(:namespaces) { [ns_a, ns_b, ns_ks, ns_knl] }
 
   let(:params) {
     {


### PR DESCRIPTION
This is an expected "system" namespace, introduced
by a change to kubernetes