### PR TITLE
Add Velero to the list of default namespaces

### DIFF
--- a/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
@@ -11,6 +11,7 @@ class ClusterNamespaceLister
     kube-system
     kuberos
     opa
+    velero
   ]
 
   def initialize(args)


### PR DESCRIPTION
This will stop the report displaying Velero as an orphaned namespace.