### PR TITLE
Update terraform version to 0.12.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.14 AS terraform
+FROM hashicorp/terraform:0.12.17 AS terraform
 
 FROM ruby:2.5-alpine
 


### PR DESCRIPTION
This is the same version we use in the latest tools image, so we should
be consistent about using it everywhere.

requires #35 

**Create release 2.25 after merging this PR**