### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,10 @@ COPY lib ./lib
 COPY bin ./bin
 
 COPY --from=terraform bin/terraform /app/bin/terraform
+
+RUN addgroup -g 1000 -S appgroup \
+  && adduser -u 1000 -S appuser -G appgroup
+
+RUN chown -R appuser:appgroup /app
+
+USER 1000


### PR DESCRIPTION
This will allow this job to be run as a kuberentes cronjob in a normal
namespace, where root container users are not permitted.

required by #33 