### PR TITLE
Add kuberhealthy to cluster namespaces

### DIFF
--- a/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
@@ -10,6 +10,7 @@ class ClusterNamespaceLister
     kube-public
     kube-system
     kuberos
+    kuberhealthy
     opa
     velero
     logging


### PR DESCRIPTION
This fixes the alerts that kuberhealthy is a "namespace with no source code in cloud-platform-environments repo"