### PR TITLE
🐛  Fixes orphaned_namespaces report

### DIFF
--- a/lib/orphaned_namespace_checker/github_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/github_namespace_lister.rb
@@ -11,9 +11,23 @@ class GithubNamespaceLister
     namespace_names.include?(namespace)
   end
 
+  
+  ## Retrieves a list of namespace names using GitHub Git Trees API
   def namespace_names
-    env_repo_namespace_path = "https://api.github.com/repos/ministryofjustice/#{env_repo}/contents/namespaces/#{cluster_name}"
-    content = URI.open(env_repo_namespace_path, "Authorization" => "token #{github_token}").read
-    JSON.parse(content).map { |hash| hash.fetch("name") }
+    env_repo_namespace_tree_path = "https://api.github.com/repos/ministryofjustice/#{env_repo}/git/trees/#{git_tree_sha}"
+    tree = URI.open(env_repo_namespace_tree_path, "Authorization" => "token #{github_token}").read
+    response = JSON.parse(tree)
+    response["tree"].map { |hash| hash.fetch("path") }
+  end
+
+  private
+
+  ## Fetch the latest sha hash of the namespace directory using GitHub Repositories Contents API, needed to contruct env_repo_namespace_tree_path
+  def git_tree_sha
+    env_repo_namespaces_content_url = "https://api.github.com/repos/ministryofjustice/#{env_repo}/contents/namespaces"
+    content = URI.open(env_repo_namespaces_content_url, "Authorization" => "token #{github_token}").read
+    response = JSON.parse(content)
+    item = response.find { |hash| hash["name"] == "#{cluster_name}" }
+    item["sha"]
   end
 end


### PR DESCRIPTION
The PR will introduce the use of [Git Trees API](https://docs.github.com/rest/git/trees#get-a-tree) to generate a list of namespace folders in the environments repo. 

This fixes the problem stated in the issue [live-orphaned-namespaces report/alert discrepancy](https://github.com/ministryofjustice/cloud-platform/issues/5765)