### PR TITLE
chore: 🤖 add filter teams ns to default namespaces

### DIFF
--- a/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
@@ -21,6 +21,7 @@ class ClusterNamespaceLister
     tigera-operator
     gatekeeper-system
     cloud-platform-label-pods
+    cloud-platform-github-teams-filter
   ]
 
   def initialize(args)


### PR DESCRIPTION
to avoid low-p alert firing in `live` for this namespace