### PR TITLE
fix: Add amazon-guardduty to orphaned namespace checker default exclusions

### DIFF
--- a/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
+++ b/lib/orphaned_namespace_checker/cluster_namespace_lister.rb
@@ -19,6 +19,7 @@ class ClusterNamespaceLister
     gatekeeper-system
     cloud-platform-label-pods
     cloud-platform-github-teams-filter
+    amazon-guardduty
   ]
 
   def initialize(args)


### PR DESCRIPTION
Add `amazon-guardduty` to orphaned namespace checker default exclusions